### PR TITLE
:recycle: [REFACTOR] 채팅 기능 수정 및 actions, jwt token 수정

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,12 @@ jobs:
           echo "${{ secrets.KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
 
+      - name: Set PROPERTIES file
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.APPLICATION_PROD_PROPERTIES }}" | base64 --decode > ./src/main/resources/application-docker.properties
+          find src
+
       - name: Docker Hub 로그인
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 

--- a/src/main/java/com/example/cloud/chat/controller/ChatHistoryController.java
+++ b/src/main/java/com/example/cloud/chat/controller/ChatHistoryController.java
@@ -1,5 +1,6 @@
 package com.example.cloud.chat.controller;
 
+import com.example.cloud.chat.dto.ChatHistoryResponseDTO;
 import com.example.cloud.chat.service.ChatHistoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,10 +17,10 @@ public class ChatHistoryController {
     private final ChatHistoryService chatHistoryService;
 
     // 특정 날짜, 특정 스터디 채팅방의 채팅 내역 조회
-    @GetMapping("/history/{studyName}/{selectDate}")
-    public List<Object> getChatHistory(@PathVariable String studyName,
-                                               @PathVariable String selectDate,
-                                                @RequestParam String token) {
+    @GetMapping("/history")
+    public ChatHistoryResponseDTO getChatHistory(@RequestParam String studyName,
+                                                 @RequestParam String selectDate,
+                                                 @CookieValue("Authorization") String token) {
         return chatHistoryService.getChatHistory(studyName, selectDate, token);
     }
 }

--- a/src/main/java/com/example/cloud/chat/controller/CreateChatRoomController.java
+++ b/src/main/java/com/example/cloud/chat/controller/CreateChatRoomController.java
@@ -1,5 +1,6 @@
 package com.example.cloud.chat.controller;
 
+import com.example.cloud.chat.dto.AddMemberRequestDTO;
 import com.example.cloud.chat.dto.CreateChatRoomRequestDTO;
 import com.example.cloud.chat.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,12 @@ public class CreateChatRoomController {
                                  CreateChatRoomRequestDTO requestDTO) {
 
         chatRoomService.createChatRoom(requestDTO);
+    }
+
+    @PostMapping("/member")
+    public void addMember(@RequestBody
+                          AddMemberRequestDTO requestDTO) {
+
+        chatRoomService.addMember(requestDTO);
     }
 }

--- a/src/main/java/com/example/cloud/chat/dto/AddMemberRequestDTO.java
+++ b/src/main/java/com/example/cloud/chat/dto/AddMemberRequestDTO.java
@@ -1,0 +1,16 @@
+package com.example.cloud.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class AddMemberRequestDTO {
+    private final String studyName;
+    private final String createdAt;
+    private final List<String> memberEmail;
+}

--- a/src/main/java/com/example/cloud/chat/dto/ChatHistoryResponseDTO.java
+++ b/src/main/java/com/example/cloud/chat/dto/ChatHistoryResponseDTO.java
@@ -1,0 +1,15 @@
+package com.example.cloud.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ChatHistoryResponseDTO {
+    private final List<Object> chatHistory;
+}
+

--- a/src/main/java/com/example/cloud/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/cloud/chat/service/ChatRoomService.java
@@ -1,6 +1,7 @@
 package com.example.cloud.chat.service;
 
 import com.example.cloud.chat.domain.MongoChatRoom;
+import com.example.cloud.chat.dto.AddMemberRequestDTO;
 import com.example.cloud.chat.dto.CreateChatRoomRequestDTO;
 import com.example.cloud.chat.repository.MongoChatRoomRepository;
 import com.example.cloud.oauth2.entity.SocialUserEntity;
@@ -48,6 +49,30 @@ public class ChatRoomService {
                 });
 
         log.info("Chat room created: {}", chatRoom);
+
+        mongoChatRoomRepository.save(chatRoom);
+    }
+
+    // 채팅방 멤버 추가
+    public void addMember(AddMemberRequestDTO requestDTO) {
+
+        // 채팅방이 이미 존재하는 지 확인
+        log.info("Checking if chat room already exists: {}", requestDTO.getStudyName() + ":" + requestDTO.getCreatedAt());
+        MongoChatRoom chatRoom = mongoChatRoomRepository.findByChatRoomName("study:" + requestDTO.getStudyName() + ":" + requestDTO.getCreatedAt())
+                .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 존재하지 않습니다."));
+
+        log.info("Adding new member to chat room: {}", requestDTO.getStudyName() + ":" + requestDTO.getCreatedAt());
+
+        List<SocialUserEntity> userList = new ArrayList<>();
+        for (String memberEmail : requestDTO.getMemberEmail()) {
+            SocialUserEntity user = userRepository.findByEmail(memberEmail)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 사용자 정보가 존재하지 않습니다."));
+            userList.add(user);
+        }
+
+        chatRoom.getMembers().addAll(userList);
+
+        log.info("Member added to chat room: {}", chatRoom);
 
         mongoChatRoomRepository.save(chatRoom);
     }

--- a/src/main/java/com/example/cloud/oauth2/config/SecurityConfig.java
+++ b/src/main/java/com/example/cloud/oauth2/config/SecurityConfig.java
@@ -33,24 +33,24 @@ public class SecurityConfig {
         // csrf 비활성화
         http.csrf((auth) -> auth.disable());
 
-//        // cors 설정
-//        http.cors(corsCustomizser -> corsCustomizser.configurationSource(new CorsConfigurationSource() {
-//            @Override
-//            public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
-//                CorsConfiguration configuration = new CorsConfiguration();
-//
-//                configuration.setAllowedOrigins(Collections.singletonList("*"));
-//                configuration.setAllowedMethods(Collections.singletonList("*"));
-//                configuration.setAllowCredentials(true);
-//                configuration.setAllowedHeaders(Collections.singletonList("*"));
-//                configuration.setMaxAge(3600L);
-//
-//                configuration.setExposedHeaders(Collections.singletonList("Set-Cookie"));
-//                configuration.setExposedHeaders(Collections.singletonList("Authorization"));
-//
-//                return configuration;
-//            }
-//        }));
+        // cors 설정
+        http.cors(corsCustomizser -> corsCustomizser.configurationSource(new CorsConfigurationSource() {
+            @Override
+            public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+                CorsConfiguration configuration = new CorsConfiguration();
+
+                configuration.setAllowedOrigins(Collections.singletonList("*"));
+                configuration.setAllowedMethods(Collections.singletonList("*"));
+                configuration.setAllowCredentials(true);
+                configuration.setAllowedHeaders(Collections.singletonList("*"));
+                configuration.setMaxAge(3600L);
+
+                configuration.setExposedHeaders(Collections.singletonList("Set-Cookie"));
+                configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+
+                return configuration;
+            }
+        }));
 
         // FormLogin 비활성화
         http.formLogin((auth) -> auth.disable());
@@ -72,7 +72,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((auth) -> auth
                     .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                    .anyRequest().permitAll());
+                    .anyRequest().authenticated());
 
 
         // 세션 설정 - JWT 방식으로 인증정보를 다룰거라 세션 상태를 STATELESS로 관리해야 함.

--- a/src/main/java/com/example/cloud/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/com/example/cloud/oauth2/dto/CustomOAuth2User.java
@@ -35,12 +35,15 @@ public class CustomOAuth2User implements OAuth2User {
         return collection;
     }
 
-    @Override
-    public String getName() {
-        return socialUserDTO.getUsername();
+    public String getEmail() {
+        return socialUserDTO.getEmail();
+    }
+    public Long getId(){
+        return socialUserDTO.getId();
     }
 
-    public String getUsername() {
+    @Override
+    public String getName() {
         return socialUserDTO.getUsername();
     }
 }

--- a/src/main/java/com/example/cloud/oauth2/dto/SocialUserDTO.java
+++ b/src/main/java/com/example/cloud/oauth2/dto/SocialUserDTO.java
@@ -6,6 +6,8 @@ import lombok.Setter;
 @Getter
 @Setter
 public class SocialUserDTO {
+    private Long id;
+    private String email;
     private String username;
     private String role;
 }

--- a/src/main/java/com/example/cloud/oauth2/entity/SocialUserEntity.java
+++ b/src/main/java/com/example/cloud/oauth2/entity/SocialUserEntity.java
@@ -4,12 +4,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class SocialUserEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/cloud/oauth2/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/example/cloud/oauth2/handler/CustomSuccessHandler.java
@@ -30,14 +30,16 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // OAuth2User
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
 
-        String username = customUserDetails.getUsername();
+        String username = customUserDetails.getName();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
         GrantedAuthority auth = iterator.next();
         String role = auth.getAuthority();
+        Long id = customUserDetails.getId();
+        String email = customUserDetails.getEmail();
 
-        String token = jwtUtil.createJwt(username, role, 60*60*60L);
+        String token = jwtUtil.createJwt(id, username, email, role, 60*100*60*60L);
         System.out.println("생성된 jwt 토큰 : " + token);
 
         response.addCookie(createCookie("Authorization", token));

--- a/src/main/java/com/example/cloud/oauth2/jwt/JWTFilter.java
+++ b/src/main/java/com/example/cloud/oauth2/jwt/JWTFilter.java
@@ -69,9 +69,14 @@ public class JWTFilter extends OncePerRequestFilter {
         //      - 토큰에서 username과 role을 획득하여 새 UserDTO를 만들어 얻은 username과 role을 넣은 후 UserDetails에 담는다.
         String username = jwtUtil.getUsername(token);
         String role = jwtUtil.getRole(token);
+        String email = jwtUtil.getUserEmail(token)
+                .orElseThrow(() -> new IllegalArgumentException("토큰 정보가 유효하지 않습니다."));
+        Long id = jwtUtil.getUserId(token);
 
         SocialUserDTO socialUserDTO = new SocialUserDTO();
         socialUserDTO.setUsername(username);
+        socialUserDTO.setId(id);
+        socialUserDTO.setEmail(email);
         socialUserDTO.setRole(role);
 
         CustomOAuth2User customOAuth2User = new CustomOAuth2User(socialUserDTO);

--- a/src/main/java/com/example/cloud/oauth2/jwt/JWTUtil.java
+++ b/src/main/java/com/example/cloud/oauth2/jwt/JWTUtil.java
@@ -29,6 +29,10 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class).describeConstable();
     }
 
+    public Long getUserId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("id", Long.class);
+    }
+
     // 받은 토큰에서 role 확인 메소드. 검증할 로직에서 호출할 것임.
     public String getRole(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
@@ -40,8 +44,10 @@ public class JWTUtil {
     }
 
     // jwt 생성 메소드
-    public String createJwt(String username, String role, Long expiredMs) {
+    public String createJwt(Long id, String username, String email, String role, Long expiredMs) {
         return Jwts.builder()
+                .claim("id", id)
+                .claim("email", email)
                 .claim("username", username)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))

--- a/src/main/java/com/example/cloud/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/cloud/oauth2/service/CustomOAuth2UserService.java
@@ -50,6 +50,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             SocialUserDTO socialUserDTO = new SocialUserDTO();
             socialUserDTO.setUsername(username);
+            socialUserDTO.setId(socialUserEntity.getId());
+            socialUserDTO.setEmail(oAuth2Response.getEmail());
             socialUserDTO.setRole("ROLE_USER");
 
             return new CustomOAuth2User(socialUserDTO);
@@ -57,10 +59,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             existData.setEmail(existData.getEmail());
 
             userRepository.save(existData);
-
             SocialUserDTO socialUserDTO = new SocialUserDTO();
             socialUserDTO.setUsername(existData.getUsername());
-            socialUserDTO.setUsername(existData.getUsername());
+            socialUserDTO.setId(existData.getId());
+            socialUserDTO.setEmail(existData.getEmail());
             socialUserDTO.setRole(existData.getRole());
 
             return new CustomOAuth2User(socialUserDTO);


### PR DESCRIPTION
## 구현 내용
- 채팅 히스토리 가져오기, 채팅방 생성 등 API 추가 했습니다.
## 수정 내용 
- JWT 토큰에 id, email이 추가되도록 했고, 중복되는 name과 username은 수정했습니다. 이제 cookie에 Authoriation을 key로 하고 token을 value에 넣으면 검증이 잘 됩니다. 
- properties 파일을 github에서 숨겼기 때문에 actions 실행 및 빌드 시에 사용할 properties 파일을 불러와서 action될 때 같이 들어가게 했습니다. 
## 참고 내용
- compose는 안 만들어도 될 것 같습니다. 어차피 redis나 mongo는 계속 컨테이너로 켜둘 것 같아서 기존 script 코드는 유지시켰습니다. 
